### PR TITLE
Suporte para codigo de estado do IBGE

### DIFF
--- a/ie.js
+++ b/ie.js
@@ -583,7 +583,7 @@ var codigosIBGE = {
 
 function validar(ie, estado){
     if(estado && !isNaN(estado)) {
-        if(!Object.keys(codigosIBGE).includes(estado)){
+        if(!Object.keys(codigosIBGE).includes(String(estado))){
             throw new Error('código não é valido');
         }
         estado = codigosIBGE[estado];

--- a/ie.js
+++ b/ie.js
@@ -551,7 +551,44 @@ function lookup(ie){
     }
 }
 
+var codigosIBGE = {
+    11:	'RO',
+    13:	'AM',
+    12:	'AC',
+    14:	'RR',
+    15:	'PA',
+    16:	'AP',
+    17:	'TO',
+    21:	'MA',
+    22:	'PI',
+    23:	'CE',
+    24:	'RN',
+    25:	'PB',
+    26:	'PE',
+    27:	'AL',
+    28:	'SE',
+    29:	'BA',
+    31:	'MG',
+    32: 'ES',
+    33: 'RJ',
+    35:	'SP',
+    41:	'PR',
+    42:	'SC',
+    43:	'RS',
+    50:	'MS',
+    51:	'MT',
+    52:	'GO',
+    53:	'DF',
+};
+
 function validar(ie, estado){
+    if(estado && !isNaN(estado)) {
+        if(!Object.keys(codigosIBGE).includes(estado)){
+            throw new Error('código não é valido');
+        }
+        estado = codigosIBGE[estado];
+    }
+
     if(eIndefinido(estado) || estado === null){
         estado = '';
     }

--- a/testes/lookupTeste.js
+++ b/testes/lookupTeste.js
@@ -27,6 +27,15 @@ module.exports = {
         test.doesNotThrow(function(){ inscricaoEstadual('012345679', ''); });
         test.done();
     },
+    'Passando codigo do IBGE no estado funciona': function(test){
+        test.doesNotThrow(function(){ inscricaoEstadual('012345679', '43'); });
+        test.done();
+    },
+
+    'Passando codigo do IBGE invalido no estado da erro': function(test){
+        test.throws(function(){ inscricaoEstadual('012345679', '123'); });
+        test.done();
+    },
 
     'Não passando inscrição estadual lança erro': function(test){
         test.throws(function(){ inscricaoEstadual(); });


### PR DESCRIPTION
Tendo em vista que muitos desenvolvedores utilizam o codigo do estado no IBGE ao invés da sigla desenvolvi essa feature em um fork e publiquei para conseguir utilizar no meu projeto.